### PR TITLE
Added a space between save button and text

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -99,6 +99,10 @@
     height: 30px;
 }
 
+.trycount{
+    margin-top: 20px;
+}
+
 @media (min-width: 480px) {
     .question_save {
         margin-left: 8em;


### PR DESCRIPTION
As there was no space between the save button and the text that says
how much time is left to answer the question (in all Moodle themes) I
added a margin.

View before change in CSS:
![save_button_before](https://cloud.githubusercontent.com/assets/4711883/8697486/9a301f6e-2af5-11e5-92e3-8d7b5b482397.png)

After change:
![save_button_with_margin](https://cloud.githubusercontent.com/assets/4711883/8697489/a5bb36de-2af5-11e5-8b15-0827c684994c.png)
