### PR TITLE
Fully anonymize data (when set)

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -38,6 +38,7 @@ student gave.  Students will also be able to view their attempts based on the di
 
 Changes:
 --------
+2016-01-04 - Anonymize option now anonymizes the data stored in the database - it is not available for review or to update the gradebook
 2015-12-03 - Fixing sortablejs to not try to attach to moodle's AMD loader so that it will work, otherwise the plugin works as it should for 3.0
 2015-07-22 - Adding anonymize responses for the instructor view during a quiz.  This feature does not anonymize for grading or student/group review
 2015-07-08 - Fixing a missing strings issue, along with question category searching not working on Moodle 2.7 branch

--- a/backup/moodle2/restore_activequiz_stepslib.php
+++ b/backup/moodle2/restore_activequiz_stepslib.php
@@ -134,7 +134,9 @@ class restore_activequiz_activity_structure_step extends restore_questions_activ
         $oldid = $data->id;
         $data->sessionid = $this->get_new_parentid('activequiz_session');
 
-        $data->userid = $this->get_mappingid('user', $data->userid);
+        if ($data->userid > 0) {
+            $data->userid = $this->get_mappingid('user', $data->userid);
+        }
         $data->forgroupid = $this->get_mappingid('group', $data->forgroupid);
 
         $data->timestart = $this->apply_date_offset($data->timestart);

--- a/classes/activequiz.php
+++ b/classes/activequiz.php
@@ -284,6 +284,15 @@ class activequiz {
     }
 
     /**
+     * Are the responses anonymous?
+     *
+     * @return bool
+     */
+    public function is_anonymous() {
+        return (bool)$this->activequiz->anonymizeresponses;
+    }
+
+    /**
      * Gets the review options for the specified time
      *
      * @param string $whenname The review options time that we want to get the options for

--- a/classes/controllers/quizdata.php
+++ b/classes/controllers/quizdata.php
@@ -131,8 +131,6 @@ class quizdata {
      *
      */
     public function handle_request() {
-        global $USER;
-
         switch ($this->action) {
             case 'startquiz':
 
@@ -183,7 +181,7 @@ class quizdata {
                 $qattempt = $this->session->get_open_attempt();
 
                 // make sure the attempt belongs to the current user
-                if ($qattempt->userid != $USER->id) {
+                if ($qattempt->userid != $this->session->get_current_userid()) {
                     $this->jsonlib->send_error('invalid user');
                 }
 

--- a/classes/controllers/viewquizattempt.php
+++ b/classes/controllers/viewquizattempt.php
@@ -169,6 +169,9 @@ class viewquizattempt {
                             'sessionid'    => $attempt->sessionid
                         )
                     );
+                    if ($params['relateduserid'] < 0) {
+                        $params['relateduserid'] = 0; // Blank out anonymous users.
+                    }
 
                     $event = \mod_activequiz\event\attempt_viewed::create($params);
                     $event->add_record_snapshot('activequiz_attempts', $attempt->get_attempt());

--- a/classes/tableviews/sessionattempts.php
+++ b/classes/tableviews/sessionattempts.php
@@ -115,14 +115,21 @@ class sessionattempts extends \flexible_table implements \renderable {
 
             if (!$download) {
 
+                if ($item->userid > 0) {
+                    $userlink = '<a href="'.$CFG->wwwroot.'/user/view.php?id='.$item->userid.
+                        '&amp;course='.$this->rtq->getCourse()->id.'">';
+                    $userlinkend = '</a>';
+                } else {
+                    $userlink = '';
+                    $userlinkend = '';
+                }
+
                 if ($this->rtq->group_mode()) {
 
-                    $userlink = $item->groupname . ' (<a href="' . $CFG->wwwroot . '/user/view.php?id=' . $item->userid .
-                        '&amp;course=' . $this->rtq->getCourse()->id . '">' . $item->takenby . '</a>)';
+                    $userlink = $item->groupname . ' (' .$userlink . $item->takenby . $userlinkend . ')';
 
                 } else {
-                    $userlink = '<a href="' . $CFG->wwwroot . '/user/view.php?id=' . $item->userid .
-                        '&amp;course=' . $this->rtq->getCourse()->id . '">' . $item->username . '</a>';
+                    $userlink = $userlink . $item->username . $userlinkend;
                 }
                 $row[] = $userlink;
             } else {
@@ -186,7 +193,9 @@ class sessionattempts extends \flexible_table implements \renderable {
         $attempts = $this->session->getall_attempts(true);
         $userids = array();
         foreach ($attempts as $attempt) {
-            $userids[] = $attempt->userid;
+            if ($attempt->userid > 0) {
+                $userids[] = $attempt->userid;
+            }
         }
 
         // get user records to get the full name
@@ -203,16 +212,22 @@ class sessionattempts extends \flexible_table implements \renderable {
             $ditem = new \stdClass();
             $ditem->attemptid = $attempt->id;
             $ditem->sessionid = $attempt->sessionid;
+            if (isset($userrecs[$attempt->userid])) {
+                $name = fullname($userrecs[$attempt->userid]);
+                $userid = $attempt->userid;
+            } else {
+                $name = get_string('anonymoususer', 'mod_activequiz');
+                $userid = null;
+            }
             if ($this->rtq->group_mode()) {
 
-                $ditem->userid = $attempt->userid;
-                $ditem->takenby = fullname($userrecs[ $attempt->userid ]);
+                $ditem->userid = $userid;
+                $ditem->takenby = $name;
                 $ditem->groupname = $this->rtq->get_groupmanager()->get_group_name($attempt->forgroupid);
 
             } else {
-                $ditem->userid = $attempt->userid;
-                $userrec = $userrecs[ $attempt->userid ];
-                $ditem->username = fullname($userrec);
+                $ditem->userid = $userid;
+                $ditem->username = $name;
             }
 
             $ditem->attemptno = $attempt->attemptnum;

--- a/classes/utils/grade.php
+++ b/classes/utils/grade.php
@@ -158,6 +158,9 @@ class grade {
     protected function process_sessions($sessions, $userid = null) {
         global $DB;
 
+        if ($userid && $userid < 0) {
+            return true; // Ignore attempts to update the grades for an anonymous user.
+        }
 
         $sessionsgrades = array();
         foreach ($sessions as $session) {
@@ -186,6 +189,9 @@ class grade {
 
                 foreach ($session->get_session_users() as $user) {
                     $uid = $user->userid;
+                    if ($uid < 0) {
+                        continue; // Ignore anonymous users.
+                    }
                     if (!isset($sessionsgrades[ $uid ])) { // add the userid to the sessions grade as an array
                         $sessionsgrades[ $uid ] = array();
                     }

--- a/lang/en/activequiz.php
+++ b/lang/en/activequiz.php
@@ -81,7 +81,7 @@ $string['grademethod_help'] = 'This is the method that is used when grading.  Th
 $string['assessed'] = 'Assessed';
 $string['assessed_help'] = 'Check this box to make your quiz assessed';
 $string['anonymousresponses'] = 'Anonymize student responses';
-$string['anonymousresponses_help'] = 'Anonymize student responses for the instructor\'s view so that if their screen is being shown, student\'s names or group names will not be shown';
+$string['anonymousresponses_help'] = 'Fully anonymize student responses to make it difficult to match them back to the users who gave those responses.<br>The gradebook will never be updated for students who take the quiz whilst this setting is on.';
 
 $string['groupworksettings'] = 'Group settings';
 $string['nochangegroups_label'] = '&nbsp;';
@@ -180,6 +180,7 @@ $string['reload_results'] = 'Reload Results';
 $string['notresponded'] = 'Number not responded out of attempts';
 $string['trycount'] = 'You have {$a->tries} tries left.';
 $string['waitforrevewingend'] = 'The instructor is currently reviewing the previous question.  Please wait for the next question to start';
+$string['isanonymous'] = 'All responses to this active quiz are anonymous';
 
 $string['show_correct_answer'] = 'Show correct answer';
 $string['hide_correct_answer'] = 'Hide correct answer';
@@ -272,6 +273,7 @@ $string['activitygrades'] = 'Activity grades: ';
 $string['groupmembership'] = 'Group membership';
 $string['regradeallgrades'] = 'Regrade all grades';
 $string['successregrade'] = 'Successfully regraded quiz';
+$string['anonymoususer'] = 'Anonymous user';
 
 // session attempts table
 $string['attemptno'] = 'Attempt Number';

--- a/mod_form.php
+++ b/mod_form.php
@@ -68,7 +68,7 @@ class mod_activequiz_mod_form extends moodleform_mod {
         $mform->setType('waitforquestiontime', PARAM_INT);
         $mform->addHelpButton('waitforquestiontime', 'waitforquestiontime', 'activequiz');
 
-        $mform->addElement('checkbox', 'anonymizeresponses', get_string('anonymousresponses', 'activequiz'));
+        $mform->addElement('advcheckbox', 'anonymizeresponses', get_string('anonymousresponses', 'activequiz'));
         $mform->addHelpButton('anonymizeresponses', 'anonymousresponses', 'activequiz');
         $mform->setDefault('anonymizeresponses', 0);
 

--- a/renderer.php
+++ b/renderer.php
@@ -318,6 +318,10 @@ class mod_activequiz_renderer extends plugin_renderer_base {
             $output .= html_writer::div('', 'activequizbox hidden', array('id' => 'notrespondedbox'));
         }
 
+        if ($this->rtq->is_anonymous()) {
+            $output .= html_writer::div(get_string('isanonymous', 'mod_activequiz'), 'activequizbox isanonymous');
+        }
+
         // have a quiz information box to show statistics, feedback and more
         $output .= html_writer::div('', 'activequizbox hidden', array('id' => 'quizinfobox'));
 
@@ -688,7 +692,7 @@ EOD;
         $response = html_writer::start_div('response');
 
         // check if group mode, if so, give the group name the attempt is for
-        if($this->rtq->getRTQ()->anonymizeresponses == 1){
+        if($this->rtq->is_anonymous()){
             if($this->rtq->group_mode()){
                 $name = get_string('group') . ' ' . $responsecount;
             }else{
@@ -698,8 +702,11 @@ EOD;
             if ($this->rtq->group_mode()) {
                 $name = $this->rtq->get_groupmanager()->get_group_name($attempt->forgroupid);
             } else {
-                $user = $DB->get_record('user', array('id' => $attempt->userid));
-                $name = fullname($user);
+                if ($user = $DB->get_record('user', array('id' => $attempt->userid))) {
+                    $name = fullname($user);
+                } else {
+                    $name = get_string('anonymoususer', 'mod_activequiz');
+                }
             }
         }
 
@@ -731,7 +738,7 @@ EOD;
         $output .= html_writer::end_div();
 
         // output the list of students, but only if we're not in anonymous mode
-        if($this->rtq->getRTQ()->anonymizeresponses == 0){
+        if(!$this->rtq->is_anonymous()){
             $output .= html_writer::start_div();
             $output .= html_writer::alist($notresponded, array('id' => 'notrespondedlist'));
             $output .= html_writer::end_div();

--- a/styles.css
+++ b/styles.css
@@ -278,3 +278,7 @@
     display: none;
     visibility: hidden;
 }
+
+.activequizbox.isanonymous {
+    background-color: #d7f5d7;
+}

--- a/version.php
+++ b/version.php
@@ -23,7 +23,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2015120300;  // The current module version (Date: YYYYMMDDXX)
+$plugin->version = 2016010400;  // The current module version (Date: YYYYMMDDXX)
 $plugin->requires = 2015051100;  // Moodle 2.9 (or above)
 $plugin->cron = 0;           // Period for cron to check this module (secs)
 $plugin->component = 'mod_activequiz';


### PR DESCRIPTION
This patch adjusts the 'anoymize responses' setting, so that student userids are all set to a random negative number when this setting is on.

This setting can be turned on or off between attempts, but any data stored during anonymous sessions will be difficult to match back to the original user (examining server logs + network traffic may still make it possible to reveal identities).
