### PR TITLE
Set the lastquestion flag if required on quiz start

### DIFF
--- a/js/instructor.js
+++ b/js/instructor.js
@@ -118,6 +118,7 @@ activequiz.start_quiz = function () {
             // disable the next question button
             var nextquestionbtn = document.getElementById('nextquestion');
             nextquestionbtn.disabled = true;
+            activequiz.set('lastquestion', 'true');
         }
 
         activequiz.waitfor_question(response.questionid, response.questiontime, response.delay, response.nextstarttime);


### PR DESCRIPTION
If you have a quiz with exactly one question in it and start a session, after clicking 'end question' the 'next question' button is clickable and returns an error.

This is fixed by setting the lastquestion flag on the initial quiz start.