### PR TITLE
Switch field type for questionengid to int

### DIFF
--- a/db/install.xml
+++ b/db/install.xml
@@ -81,7 +81,7 @@
         <FIELD NAME="sessionid" TYPE="int" LENGTH="11" NOTNULL="true" SEQUENCE="false" COMMENT="The session this attempt belongs to"/>
         <FIELD NAME="userid" TYPE="int" LENGTH="11" NOTNULL="true" SEQUENCE="false" COMMENT="The userid for this attempt"/>
         <FIELD NAME="attemptnum" TYPE="int" LENGTH="11" NOTNULL="false" SEQUENCE="false" COMMENT="The attempt number for this user, for this session"/>
-        <FIELD NAME="questionengid" TYPE="char" LENGTH="50" NOTNULL="true" SEQUENCE="false" COMMENT="The unique id that is used for the question engine's usage for loading the activity by id."/>
+        <FIELD NAME="questionengid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="The unique id that is used for the question engine's usage for loading the activity by id."/>
         <FIELD NAME="status" TYPE="int" LENGTH="5" NOTNULL="true" SEQUENCE="false" COMMENT="The status of the attempt"/>
         <FIELD NAME="preview" TYPE="int" LENGTH="1" NOTNULL="true" SEQUENCE="false" COMMENT="bit as to wether or not this is a preview attempt"/>
         <FIELD NAME="responded" TYPE="int" LENGTH="1" NOTNULL="false" DEFAULT="0" SEQUENCE="false" COMMENT="whether or not the user responded for the particular sesson's current question"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -127,5 +127,16 @@ function xmldb_activequiz_upgrade($oldversion) {
         upgrade_mod_savepoint(true, 2015072200, 'activequiz');
     }
 
+    if ($oldversion < 2015120301) {
+        $table = new xmldb_table('activequiz_attempts');
+        $field = new xmldb_field('questionengid', XMLDB_TYPE_INTEGER, '10', XMLDB_UNSIGNED, XMLDB_NOTNULL, null, null, 'attemptnum');
+        if ($dbman->field_exists($table, $field)) {
+            $dbman->change_field_type($table, $field);
+        }
+
+        // Activequiz savepoint reached.
+        upgrade_mod_savepoint(true, 2015120301, 'activequiz');
+    }
+
     return true;
 }

--- a/version.php
+++ b/version.php
@@ -23,7 +23,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2015120300;  // The current module version (Date: YYYYMMDDXX)
+$plugin->version = 2015120301;  // The current module version (Date: YYYYMMDDXX)
 $plugin->requires = 2015051100;  // Moodle 2.9 (or above)
 $plugin->cron = 0;           // Period for cron to check this module (secs)
 $plugin->component = 'mod_activequiz';


### PR DESCRIPTION
Without this change, the question engine attempts to compare a char with
an int, which fails under postgresql - making it impossible to delete
activequiz modules.

This includes a version bump due to the db schema change. From what I've seen the questionengid field only ever gets filled with an int id from the question engine, so there should be no issue changing the type to int here.