### PR TITLE
Anonymize functionality & fix #39

### DIFF
--- a/backup/moodle2/backup_activequiz_stepslib.php
+++ b/backup/moodle2/backup_activequiz_stepslib.php
@@ -61,8 +61,8 @@ class backup_activequiz_activity_structure_step extends backup_questions_activit
 
         $sessions = new backup_nested_element('sessions');
         $session = new backup_nested_element('session', array('id'), array(
-            'name', 'sessionopen', 'status', 'currentquestion', 'currentqnum', 'currentquestiontime',
-            'classresult', 'nextstarttime', 'created'
+            'name', 'anonymize_responses', 'fully_anonymize', 'sessionopen', 'status', 'currentquestion',
+            'currentqnum', 'currentquestiontime', 'classresult', 'nextstarttime', 'created'
         ));
 
         $attempts = new backup_nested_element('attempts');

--- a/classes/activequiz_attempt.php
+++ b/classes/activequiz_attempt.php
@@ -200,6 +200,24 @@ class activequiz_attempt {
     }
 
     /**
+     * @param int $slotnum The slot number to check
+     * @param int $tottries The total tries
+     *
+     * @return int The number of tries left
+     */
+    public function check_tries_left($slotnum, $tottries) {
+
+
+        if( empty($this->attempt->responded_count) ){
+            $this->attempt->responded_count = 0;
+        }
+
+        $left = $tottries - $this->attempt->responded_count;
+
+        return $left;
+    }
+
+    /**
      * sets up the display options for the question
      *
      * @return \question_display_options
@@ -448,6 +466,12 @@ class activequiz_attempt {
         }
         $this->attempt->timemodified = time();
         $this->attempt->responded = 1;
+
+        if(empty($this->attempt->responded_count)){
+            $this->attempt->responded_count = 0;
+        }
+        $this->attempt->responded_count = $this->attempt->responded_count + 1;
+
         $this->save();
 
         $transaction->allow_commit();

--- a/classes/activequiz_session.php
+++ b/classes/activequiz_session.php
@@ -312,6 +312,7 @@ class activequiz_session {
             /** @var \mod_activequiz\activequiz_attempt $attempt */
 
             $attempt->responded = 0;
+            $attempt->responded_count = 0;
             $attempt->save();
         }
 
@@ -470,6 +471,7 @@ class activequiz_session {
             $attempt->timemodified = time();
             $attempt->timestart = time();
             $attempt->responded = null;
+            $attempt->responded_count = 0;
             $attempt->timefinish = null;
 
             // add forgroupid to attempt if we're in group mode

--- a/classes/activequiz_session.php
+++ b/classes/activequiz_session.php
@@ -544,7 +544,7 @@ class activequiz_session {
 
         // Full Anonymisation is on, so generate a random ID and store it in the USER variable (kept until the user logs out).
         if (empty($USER->mod_activequiz_anon_userid)) {
-            $USER->mod_activequiz_anon_userid = -mt_rand(100000);
+            $USER->mod_activequiz_anon_userid = -mt_rand(100000, mt_getrandmax());
         }
 
         return $USER->mod_activequiz_anon_userid;

--- a/classes/controllers/quizdata.php
+++ b/classes/controllers/quizdata.php
@@ -126,7 +126,6 @@ class quizdata {
      *
      */
     public function handle_request() {
-        global $USER;
 
         switch ($this->action) {
             case 'startquiz':
@@ -178,7 +177,7 @@ class quizdata {
                 $qattempt = $this->session->get_open_attempt();
 
                 // make sure the attempt belongs to the current user
-                if ($qattempt->userid != $USER->id) {
+                if ($qattempt->userid != $this->session->get_current_userid()) {
                     $this->jsonlib->send_error('invalid user');
                 }
 

--- a/classes/controllers/view.php
+++ b/classes/controllers/view.php
@@ -264,7 +264,7 @@ class view {
                             $this->RTQ->get_renderer()->view_footer();
                             break;
                         } else {
-                            if (!$this->session->create_session($data->sessionname)) {
+                            if (!$this->session->create_session($data)) {
                                 // error handling
                                 $this->RTQ->get_renderer()->setMessage(get_string('unabletocreate_session', 'activequiz'), 'error');
                                 $this->RTQ->get_renderer()->view_header();

--- a/classes/controllers/viewquizattempt.php
+++ b/classes/controllers/viewquizattempt.php
@@ -166,6 +166,10 @@ class viewquizattempt {
                         )
                     );
 
+                    if( $attempt->userid < 0) {
+                        $params['relateduserid'] = 0;
+                    }
+
                     $event = \mod_activequiz\event\attempt_viewed::create($params);
                     $event->add_record_snapshot('activequiz_attempts', $attempt->get_attempt());
                     $event->trigger();

--- a/classes/forms/view/start_session.php
+++ b/classes/forms/view/start_session.php
@@ -57,6 +57,15 @@ class start_session extends \moodleform {
         $mform->setType('sessionname', PARAM_TEXT);
         $mform->addRule('sessionname', get_string('sessionname_required', 'activequiz'), 'required', null, 'client');
 
+        $mform->addElement('advcheckbox', 'anonymizeresponses', get_string('anonymousresponses', 'activequiz'));
+        $mform->addHelpButton('anonymizeresponses', 'anonymousresponses', 'activequiz');
+        $mform->setDefault('anonymizeresponses', 1);
+        $mform->disabledIf('anonymizeresponses', 'fullanonymize', 'checked');
+
+        $mform->addElement('advcheckbox', 'fullanonymize', get_string('fullanonymize', 'activequiz'));
+        $mform->addHelpButton('fullanonymize', 'fullanonymize', 'activequiz');
+        $mform->setDefault('fullanonymize', 0);
+
         $mform->addElement('submit', 'submitbutton', get_string('start_session', 'activequiz'));
     }
 

--- a/classes/tableviews/sessionattempts.php
+++ b/classes/tableviews/sessionattempts.php
@@ -114,14 +114,28 @@ class sessionattempts extends \flexible_table implements \renderable {
 
             if (!$download) {
 
+
+                if ($item->userid > 0) {
+                    $userlink = '<a href="'.$CFG->wwwroot.'/user/view.php?id='.$item->userid.
+                            '&amp;course='.$this->rtq->getCourse()->id.'">';
+                    $userlinkend = '</a>';
+                } else {
+                    $userlink = '';
+                    $userlinkend = '';
+                }
+
                 if ($this->rtq->group_mode()) {
 
-                    $userlink = $item->groupname . ' (<a href="' . $CFG->wwwroot . '/user/view.php?id=' . $item->userid .
-                        '&amp;course=' . $this->rtq->getCourse()->id . '">' . $item->takenby . '</a>)';
+                    //$userlink = $item->groupname . ' (<a href="' . $CFG->wwwroot . '/user/view.php?id=' . $item->userid .
+                        //'&amp;course=' . $this->rtq->getCourse()->id . '">' . $item->takenby . '</a>)';
+
+                    $userlink = $item->groupname . ' (' .$userlink . $item->takenby . $userlinkend . ')';
 
                 } else {
-                    $userlink = '<a href="' . $CFG->wwwroot . '/user/view.php?id=' . $item->userid .
-                        '&amp;course=' . $this->rtq->getCourse()->id . '">' . $item->username . '</a>';
+                    //$userlink = '<a href="' . $CFG->wwwroot . '/user/view.php?id=' . $item->userid .
+                        //'&amp;course=' . $this->rtq->getCourse()->id . '">' . $item->username . '</a>';
+
+                    $userlink = $userlink . $item->username . $userlinkend;
                 }
                 $row[] = $userlink;
             } else {
@@ -185,7 +199,9 @@ class sessionattempts extends \flexible_table implements \renderable {
         $attempts = $this->session->getall_attempts(true);
         $userids = array();
         foreach ($attempts as $attempt) {
-            $userids[] = $attempt->userid;
+            if ($attempt->userid > 0) {
+                $userids[] = $attempt->userid;
+            }
         }
 
         // get user records to get the full name
@@ -202,16 +218,24 @@ class sessionattempts extends \flexible_table implements \renderable {
             $ditem = new \stdClass();
             $ditem->attemptid = $attempt->id;
             $ditem->sessionid = $attempt->sessionid;
+
+            if( isset($userrecs[$attempt->userid]) ) {
+                $name = fullname($userrecs[$attempt->userid]);
+                $userid = $attempt->userid;
+            }else {
+                $name = get_string('anonymoususer', 'mod_activequiz');
+                $userid = null;
+            }
+
             if ($this->rtq->group_mode()) {
 
-                $ditem->userid = $attempt->userid;
-                $ditem->takenby = fullname($userrecs[ $attempt->userid ]);
+                $ditem->userid = $userid;
+                $ditem->takenby = $name;
                 $ditem->groupname = $this->rtq->get_groupmanager()->get_group_name($attempt->forgroupid);
 
             } else {
-                $ditem->userid = $attempt->userid;
-                $userrec = $userrecs[ $attempt->userid ];
-                $ditem->username = fullname($userrec);
+                $ditem->userid = $userid;
+                $ditem->username = $name;
             }
 
             $ditem->attemptno = $attempt->attemptnum;

--- a/db/install.xml
+++ b/db/install.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB PATH="mod/activequiz/db" VERSION="20160228" COMMENT="XMLDB file for Moodle mod/activequiz"
+<XMLDB PATH="mod/activequiz/db" VERSION="20160306" COMMENT="XMLDB file for Moodle mod/activequiz"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="../../../lib/xmldb/xmldb.xsd"
 >
@@ -86,6 +86,7 @@
         <FIELD NAME="status" TYPE="int" LENGTH="5" NOTNULL="true" SEQUENCE="false" COMMENT="The status of the attempt"/>
         <FIELD NAME="preview" TYPE="int" LENGTH="1" NOTNULL="true" SEQUENCE="false" COMMENT="bit as to wether or not this is a preview attempt"/>
         <FIELD NAME="responded" TYPE="int" LENGTH="1" NOTNULL="false" DEFAULT="0" SEQUENCE="false" COMMENT="whether or not the user responded for the particular sesson's current question"/>
+        <FIELD NAME="responded_count" TYPE="int" LENGTH="11" NOTNULL="false" DEFAULT="0" SEQUENCE="false" COMMENT="Number of times the current question had been responded to for the attempt"/>
         <FIELD NAME="forgroupid" TYPE="int" LENGTH="10" NOTNULL="false" DEFAULT="0" SEQUENCE="false" COMMENT="This is used when the activequiz is set up to be in groups.  The groupid will go here to signify that this attempt is for that group"/>
         <FIELD NAME="timestart" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="datetime/timestampe for when the attempt was started"/>
         <FIELD NAME="timefinish" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="the datetime/timestamp for when the attempt was finished"/>

--- a/db/install.xml
+++ b/db/install.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB PATH="mod/activequiz/db" VERSION="20150722" COMMENT="XMLDB file for Moodle mod/activequiz"
+<XMLDB PATH="mod/activequiz/db" VERSION="20160228" COMMENT="XMLDB file for Moodle mod/activequiz"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="../../../lib/xmldb/xmldb.xsd"
 >
@@ -20,7 +20,6 @@
         <FIELD NAME="reviewoptions" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="JSON encoded string of the review options from the mod form"/>
         <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
         <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="anonymizeresponses" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="stores the bit value for whether or not we are showing student's names during the quiz"/>
         <FIELD NAME="defaultquestiontime" TYPE="int" LENGTH="3" NOTNULL="true" DEFAULT="30" SEQUENCE="false" COMMENT="How long do they get for each question?"/>
         <FIELD NAME="waitforquestiontime" TYPE="int" LENGTH="11" NOTNULL="true" DEFAULT="5" SEQUENCE="false" COMMENT="The time to wait for a question before displaying students the question"/>
         <FIELD NAME="questionorder" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="The question order for the activequiz"/>
@@ -49,6 +48,8 @@
         <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
         <FIELD NAME="activequizid" TYPE="int" LENGTH="11" NOTNULL="true" SEQUENCE="false" COMMENT="the activequizid for the sessions"/>
         <FIELD NAME="name" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false" COMMENT="the session name"/>
+        <FIELD NAME="anonymize_responses" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="1" SEQUENCE="false" COMMENT="Anonymize student names within a session"/>
+        <FIELD NAME="fully_anonymize" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Fully anonymize the session, meaning that userids will not be kept for attempts and therefore grading will not be possible for the session"/>
         <FIELD NAME="sessionopen" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="whether or not the session is open"/>
         <FIELD NAME="status" TYPE="char" LENGTH="50" NOTNULL="true" SEQUENCE="false" COMMENT="the current status/state of the session"/>
         <FIELD NAME="currentquestion" TYPE="int" LENGTH="11" NOTNULL="false" SEQUENCE="false" COMMENT="The current question that the session is on"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -137,7 +137,7 @@ function xmldb_activequiz_upgrade($oldversion) {
         upgrade_mod_savepoint(true, 2016013100, 'activequiz');
     }
 
-    if( $oldversion < 2016022800 ) {
+    if( $oldversion < 2016030601 ) {
 
         // Define field anonymizeresponses to be dropped from activequiz.
         $table = new xmldb_table('activequiz');
@@ -166,8 +166,18 @@ function xmldb_activequiz_upgrade($oldversion) {
             $dbman->add_field($table, $field);
         }
 
+        // Define field responded_count to be added to activequiz_attempts.
+        $table = new xmldb_table('activequiz_attempts');
+        $field = new xmldb_field('responded_count', XMLDB_TYPE_INTEGER, '11', null, null, null, '0', 'responded');
+
+        // Conditionally launch add field responded_count.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+
         // Activequiz savepoint reached.
-        upgrade_mod_savepoint(true, 2016022800, 'activequiz');
+        upgrade_mod_savepoint(true, 2016030601, 'activequiz');
     }
 
     return true;

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -137,5 +137,38 @@ function xmldb_activequiz_upgrade($oldversion) {
         upgrade_mod_savepoint(true, 2016013100, 'activequiz');
     }
 
+    if( $oldversion < 2016022800 ) {
+
+        // Define field anonymizeresponses to be dropped from activequiz.
+        $table = new xmldb_table('activequiz');
+        $field = new xmldb_field('anonymizeresponses');
+
+        // Conditionally launch drop field anonymizeresponses.
+        if ($dbman->field_exists($table, $field)) {
+            $dbman->drop_field($table, $field);
+        }
+
+        // Define field anonymize_responses to be added to activequiz_sessions.
+        $table = new xmldb_table('activequiz_sessions');
+        $field = new xmldb_field('anonymize_responses', XMLDB_TYPE_INTEGER, '1', null, XMLDB_NOTNULL, null, '1', 'name');
+
+        // Conditionally launch add field anonymize_responses.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Define field fully_anonymize to be added to activequiz_sessions.
+        $table = new xmldb_table('activequiz_sessions');
+        $field = new xmldb_field('fully_anonymize', XMLDB_TYPE_INTEGER, '1', null, XMLDB_NOTNULL, null, '0', 'anonymize_responses');
+
+        // Conditionally launch add field fully_anonymize.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Activequiz savepoint reached.
+        upgrade_mod_savepoint(true, 2016022800, 'activequiz');
+    }
+
     return true;
 }

--- a/js/student.js
+++ b/js/student.js
@@ -112,7 +112,9 @@ activequiz.handle_question = function (questionid, hide) {
     // if there are multiple tries for this question then don't hide the question container
     if (hide) {
         var qbox = document.getElementById('q' + questionid + '_container');
-        qbox.classList.add('hidden');
+        if(typeof qbox !== 'undefined') {
+            qbox.classList.add('hidden');
+        }
     }
 
 

--- a/lang/en/activequiz.php
+++ b/lang/en/activequiz.php
@@ -185,6 +185,7 @@ $string['sessionclosed'] = 'Session is now closed';
 $string['reload_results'] = 'Reload Results';
 $string['notresponded'] = 'Number not responded out of attempts';
 $string['trycount'] = 'You have {$a->tries} tries left.';
+$string['notries'] = 'You have no tries left for this question';
 $string['waitforrevewingend'] = 'The instructor is currently reviewing the previous question.  Please wait for the next question to start';
 
 $string['show_correct_answer'] = 'Show correct answer';

--- a/lang/en/activequiz.php
+++ b/lang/en/activequiz.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-// General Strings
+// General Strings.
 $string['modulename'] = 'Active quiz';
 $string['modulename_help'] = '
 <p>The Active quiz activity enables an instructor to create and administer quizzes in real-time.  All regular quiz question types can be used in the Active Quiz.</p>
@@ -50,20 +50,20 @@ $string['activequiz:viewownattempts'] = 'Allows students to see their own attemp
 
 $string['invalidattemptaccess'] = 'You do not have permission to access this attempt';
 
-// event strings
+// event strings.
 $string['eventattemptstarted'] = 'Attempt started';
 $string['eventattemptviewed'] = 'Attempt viewed';
 $string['eventquestionmanuallygraded'] = 'Question manually graded';
 $string['eventquestionanswered'] = 'Question answered for attempt';
 
-// Scale types
+// Scale types.
 $string['firstsession'] = 'First session';
 $string['lastsession'] = 'Last session';
 $string['sessionaverage'] = 'Session average';
 $string['highestsessiongrade'] = 'Highest session grade';
 
 
-// Mod form strings
+// Mod form strings.
 $string['activequizsettings'] = 'General Active quiz settings';
 $string['activequizintro'] = 'Introduction';
 $string['defaultquestiontime'] = 'Default question time';
@@ -80,8 +80,14 @@ $string['grademethod'] = 'Session grading method';
 $string['grademethod_help'] = 'This is the method that is used when grading.  This method is for figuring out the grading with multiple sessions in the same activequiz';
 $string['assessed'] = 'Assessed';
 $string['assessed_help'] = 'Check this box to make your quiz assessed';
+
+// Anonymous strings.
 $string['anonymousresponses'] = 'Anonymize student responses';
 $string['anonymousresponses_help'] = 'Anonymize student responses for the instructor\'s view so that if their screen is being shown, student\'s names or group names will not be shown';
+$string['fullanonymize'] = 'Fully anonymize student responses';
+$string['fullanonymize_help'] = 'Fully anonymize student responses.  Please note, that if you select this option, this session\'s responses will not be graded and applied to students.';
+$string['anonymoususer'] = 'Anonymous user';
+$string['isanonymous'] = 'All responses to this active quiz are anonymous';
 
 $string['groupworksettings'] = 'Group settings';
 $string['nochangegroups_label'] = '&nbsp;';
@@ -103,7 +109,7 @@ $string['manualcomment'] = 'Manual Comment';
 $string['manualcomment_help'] = 'The comment that instructors can add when grading an attempt';
 
 
-// edit page
+// edit page.
 $string['questionlist'] = 'Question List';
 $string['addtoquiz'] = 'Add';
 $string['question'] = 'Question ';
@@ -138,7 +144,7 @@ $string['savequestion'] = 'Save question';
 $string['cantaddquestiontwice'] = 'You can not add the same question more than once to a quiz';
 $string['editpage_opensession_error'] = 'You cannot edit a quiz question or layout while a session is open.';
 
-// view page
+// view page.
 $string['quiznotrunning'] = 'Quiz not running at the moment - wait for your teacher to start it.  Use the reload button to reload this page to check again';
 $string['teacherjoinquizinstruct'] = 'Use this if you want to try out a quiz yourself<br />(you will also need to start the quiz in a separate window)';
 $string['teacherstartinstruct'] = 'Use this to start a quiz for the students to take<br />Use the textbox to define a name for this session (to help when looking through the results at a later date).';
@@ -159,7 +165,7 @@ $string['attemptstartedalready'] = 'An attempt has already been started by one o
 $string['attemptstarted'] = 'An attempt has already been started by you, please click below to continue to your open attempt';
 $string['invalidgroupid'] = 'A valid group id is required for students';
 
-/** during quiz */
+// during quiz.
 $string['startquiz'] = 'Start quiz';
 $string['waitforquestion'] = 'Waiting for the question to be sent in:';
 $string['waitstudent'] = 'Waiting for students to connect';
@@ -191,7 +197,7 @@ $string['hidestudentresponses'] = 'Hide responses';
 $string['hidenotresponded'] = 'Hide not responded';
 $string['shownotresponded'] = 'Show not responded';
 
-// Instructions
+// Instructions.
 $string['instructorquizinst'] = '<p>Please wait on this page until students have connected.  Once <b>start quiz</b> is clicked, the quiz will start the first question</p>
     <p>
 <p>Controls:</p>
@@ -266,7 +272,7 @@ $string['instructorquizinst'] = '<p>Please wait on this page until students have
 
 $string['studentquizinst'] = '<p>Please wait for the instructor to start the quiz.  Once started you will see a timer counting down to the first question start</p>';
 
-/** responses page */
+// Responses page.
 $string['selectsession'] = 'Select session to view:&nbsp;&nbsp;&nbsp;&nbsp;';
 $string['activitygrades'] = 'Activity grades: ';
 $string['groupmembership'] = 'Group membership';
@@ -274,7 +280,7 @@ $string['regradeallgrades'] = 'Regrade all grades';
 $string['successregrade'] = 'Successfully regraded quiz';
 $string['errorregrade'] = 'Sorry, there was an error in trying to re-grade all of the quizzes';
 
-// session attempts table
+// session attempts table.
 $string['attemptno'] = 'Attempt Number';
 $string['startedon'] = 'Started on';
 $string['timecompleted'] = 'Time completed';
@@ -282,13 +288,13 @@ $string['attempt_grade'] = 'Attempt grade';
 $string['response_attempt_controls'] = 'Edit/View Attempt';
 $string['timemodified'] = 'Time modified';
 
-// view own attempts table and related strings
+// view own attempts table and related strings.
 $string['sessionname'] = 'Session name';
 $string['attemptview'] = 'View attempt';
 
-// Question modifier strings
+// Question modifier strings.
 
-// Multi-Choice
+// Multi-Choice.
 $string['countdatasetlabel'] = 'Number of Answers';
 $string['percentagedatasetlabel'] = 'Percentage of total answers';
 

--- a/mod_form.php
+++ b/mod_form.php
@@ -68,9 +68,9 @@ class mod_activequiz_mod_form extends moodleform_mod {
         $mform->setType('waitforquestiontime', PARAM_INT);
         $mform->addHelpButton('waitforquestiontime', 'waitforquestiontime', 'activequiz');
 
-        $mform->addElement('checkbox', 'anonymizeresponses', get_string('anonymousresponses', 'activequiz'));
+        /*$mform->addElement('checkbox', 'anonymizeresponses', get_string('anonymousresponses', 'activequiz'));
         $mform->addHelpButton('anonymizeresponses', 'anonymousresponses', 'activequiz');
-        $mform->setDefault('anonymizeresponses', 0);
+        $mform->setDefault('anonymizeresponses', 0); */
 
         $mform->addElement('header', 'gradesettings', get_string('gradesettings', 'activequiz'));
 

--- a/renderer.php
+++ b/renderer.php
@@ -627,6 +627,9 @@ EOD;
                         $timeLeft = $nextQuestion->getQuestionTime() - $timeelapsed;
                         $jsinfo->resumequizquestiontime = $timeLeft;
                     }
+
+                    // next check how many tries left
+                    $jsinfo->resumequestiontries = $attempt->check_tries_left($session->get_session()->currentqnum, $nextQuestion->getTries());
                 }
             } else if ($sessionstatus == 'reviewing' || $sessionstatus == 'endquestion') {
 
@@ -659,6 +662,7 @@ EOD;
             'closingsession',
             'sessionclosed',
             'trycount',
+            'notries',
             'timertext',
             'waitforrevewingend',
             'show_correct_answer',

--- a/renderer.php
+++ b/renderer.php
@@ -313,16 +313,20 @@ class mod_activequiz_renderer extends plugin_renderer_base {
 
         $output .= html_writer::div($instructions, 'activequizbox hidden', array('id' => 'instructionsbox'));
 
-        // have a quiz not responded box for the instructor to know who hasn't responded
+        // have a quiz not responded box for the instructor to know who hasn't responded.
         if ($this->rtq->is_instructor()) {
             $output .= html_writer::div('', 'activequizbox hidden', array('id' => 'notrespondedbox'));
         }
 
-        // have a quiz information box to show statistics, feedback and more
+        if($session->get_session()->fully_anonymize && $this->rtq->is_instructor() == 0) {
+            $output .= html_writer::div(get_string('isanonymous', 'mod_activequiz'), 'activequizbox isanonymous');
+        }
+
+        // have a quiz information box to show statistics, feedback and more.
         $output .= html_writer::div('', 'activequizbox hidden', array('id' => 'quizinfobox'));
 
         foreach ($attempt->getSlots() as $slot) {
-            // render question form
+            // render question form.
             $output .= $this->render_question_form($slot, $attempt);
         }
 
@@ -681,14 +685,14 @@ EOD;
      *
      * @return string HTML fragment for the response
      */
-    public function render_response($attempt, $responsecount) {
+    public function render_response($attempt, $responsecount, $anonymous = true) {
         global $DB;
 
 
         $response = html_writer::start_div('response');
 
         // check if group mode, if so, give the group name the attempt is for
-        if($this->rtq->getRTQ()->anonymizeresponses == 1){
+        if($anonymous){
             if($this->rtq->group_mode()){
                 $name = get_string('group') . ' ' . $responsecount;
             }else{
@@ -698,8 +702,12 @@ EOD;
             if ($this->rtq->group_mode()) {
                 $name = $this->rtq->get_groupmanager()->get_group_name($attempt->forgroupid);
             } else {
-                $user = $DB->get_record('user', array('id' => $attempt->userid));
-                $name = fullname($user);
+                if($user = $DB->get_record('user', array('id' => $attempt->userid))) {
+                    $name = fullname($user);
+                }else {
+                    $name = get_string('anonymoususer', 'mod_activequiz');
+                }
+
             }
         }
 
@@ -716,10 +724,11 @@ EOD;
      *
      * @param array $notresponded Array of the people who haven't responded
      * @param int   $total
+     * @param int   $anonymous (0 or 1)
      *
      * @return string HTML fragment for the amount responded
      */
-    public function respondedbox($notresponded, $total) {
+    public function respondedbox($notresponded, $total, $anonymous) {
 
         $output = '';
 
@@ -731,7 +740,7 @@ EOD;
         $output .= html_writer::end_div();
 
         // output the list of students, but only if we're not in anonymous mode
-        if($this->rtq->getRTQ()->anonymizeresponses == 0){
+        if(!$anonymous){
             $output .= html_writer::start_div();
             $output .= html_writer::alist($notresponded, array('id' => 'notrespondedlist'));
             $output .= html_writer::end_div();

--- a/styles.css
+++ b/styles.css
@@ -278,3 +278,7 @@
     display: none;
     visibility: hidden;
 }
+
+.activequizbox.isanonymous {
+    background-color: #d7f5d7;
+}

--- a/version.php
+++ b/version.php
@@ -23,10 +23,10 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2016022800;  // The current module version (Date: YYYYMMDDXX)
+$plugin->version = 2016030601;  // The current module version (Date: YYYYMMDDXX)
 $plugin->requires = 2015051100;  // Moodle 2.9 (or above)
 $plugin->cron = 0;           // Period for cron to check this module (secs)
 $plugin->component = 'mod_activequiz';
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = '3.7 (Build: 2016022800)';
+$plugin->release = '3.7 (Build: 2016030601)';
 

--- a/version.php
+++ b/version.php
@@ -23,10 +23,10 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2016013100;  // The current module version (Date: YYYYMMDDXX)
+$plugin->version = 2016022800;  // The current module version (Date: YYYYMMDDXX)
 $plugin->requires = 2015051100;  // Moodle 2.9 (or above)
 $plugin->cron = 0;           // Period for cron to check this module (secs)
 $plugin->component = 'mod_activequiz';
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = '3.7 (Build: 2016013100)';
+$plugin->release = '3.7 (Build: 2016022800)';
 


### PR DESCRIPTION
Adding in anonymize functionality, similar to what Davo Smith ( @davosmith ) proposed with his pull request.  I just added in some differences of functionality, including both the original functionality, which was to make names not visible on the instructor's screen during the quiz, and Davo's functionality of completely anonymizing a quiz, which a small fix to also anonymize step information. (Note that when completely anonymizing no grading is possible for that session)

I also moved that functionality to have the settings be placed on the session so that it is easily reversible by session instead of within the active quiz settings.  

Also worked on a fix for tries left. So that if you refresh the page, the number of tries will be what are left for the current question attempt.  Note that if the instructor re-attempts the question (either by re-polling, or "go to question") the number of tries will be reset.