### PR TITLE
Stop polling moodle after user has been logged out

### DIFF
--- a/js/instructor.js
+++ b/js/instructor.js
@@ -89,6 +89,12 @@ activequiz.getQuizInfo = function () {
                 activequiz.set('inquestion', 'false');
 
             }
+        } else if (status == 403 && response.errorcode == 'invalidsesskey') {
+            // The users session to Moodle has timed out - or they logged out.
+            window.alert(response.error);
+            // Stop here so we stop polling Moodle, until they refresh the page
+            // and have a new sesskey, these polls will fail.
+            return;
         }
 
         var time = 3000 + Math.floor(Math.random() * (100 + 100) - 100);

--- a/js/student.js
+++ b/js/student.js
@@ -75,6 +75,12 @@ activequiz.getQuizInfo = function () {
                 activequiz.quiz_info(M.util.get_string('sessionclosed', 'activequiz'));
 
             }
+        } else if (status == 403 && response.errorcode == 'invalidsesskey') {
+            // The users session to Moodle has timed out - or they logged out.
+            window.alert(response.error);
+            // Stop here so we stop polling Moodle, until they refresh the page
+            // and have a new sesskey, these polls will fail.
+            return;
         }
 
         var time = 3000 + Math.floor(Math.random() * (100 + 100) - 100);


### PR DESCRIPTION
Without this change, a browser opened to an active quiz page will poll Moodle
indefinitely - even after the user has been logged out.

Once their session is no longer active, the polling should stop as it offers
zero value.